### PR TITLE
Fix default parameters parsing and typo in logs when no links found

### DIFF
--- a/archive.py
+++ b/archive.py
@@ -208,12 +208,9 @@ def create_archive(service_file, service, resume=None):
 
 if __name__ == '__main__':
     service_file = 'ril_export.html'
-    resume = None
-    try:
-        service_file = sys.argv[1]            # path to export file
-        service = sys.argv[2] or "pocket"     # select service for file format select
-        resume = sys.argv[3]                  # timestamp to resume dowloading from
-    except IndexError:
-        pass
+    argc = len(sys.argv)
+    service_file = sys.argv[1] if argc > 1 else "ril_export.html" # path to export file
+    service = sys.argv[2] if argc > 2 else "pocket" # select service for file format select
+    resume = sys.argv[3] if argc > 3 else None # timestamp to resume dowloading from
 
     create_archive(service_file, service, resume=resume)

--- a/archive.py
+++ b/archive.py
@@ -187,7 +187,7 @@ def create_archive(service_file, service, resume=None):
 
     if not links:
         if service == "pocket":
-            print('[X] No links found in {}, is it a getpocket.com/export export?'.format(serivce_file))
+            print('[X] No links found in {}, is it a getpocket.com/export export?'.format(service_file))
         elif service == "pinboard":
             print ('[X] No links found in {}, is it a pinboard.in/export/format:json/ export?'.format(service_file))
         raise SystemExit(1)


### PR DESCRIPTION
Changed the old way parameters were parsed as this was not taking the default "ril_export.html" file when none were precised, nor the "pocket" option